### PR TITLE
[refactor] 로그인 상태 유지 및 JWT 만료 기반 자동 로그아웃 기능 추가 (#29)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "classnames": "^2.5.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.12.1",
+        "jwt-decode": "^4.0.0",
         "lucide-react": "^0.486.0",
         "path": "^0.12.7",
         "react": "^19.0.0",
@@ -4932,6 +4933,14 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "classnames": "^2.5.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.12.1",
+    "jwt-decode": "^4.0.0",
     "lucide-react": "^0.486.0",
     "path": "^0.12.7",
     "react": "^19.0.0",

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { jwtDecode } from 'jwt-decode';
 
 interface User {
   name: string;
@@ -14,6 +15,12 @@ interface AuthState {
   hydrate: () => void;
 }
 
+interface JwtPayload {
+  exp: number;
+}
+
+let logoutTimer: ReturnType<typeof setTimeout> | null = null;
+
 export const useAuthStore = create<AuthState>((set) => ({
   token: null,
   user: null,
@@ -23,12 +30,25 @@ export const useAuthStore = create<AuthState>((set) => ({
     set({ token, user });
     localStorage.setItem('token', token);
     localStorage.setItem('user', JSON.stringify(user));
+
+    // 자동 로그아웃 타이머 설정
+    const decoded = jwtDecode<JwtPayload>(token);
+    const expiresInMs = decoded.exp * 1000 - Date.now();
+
+    if (logoutTimer) clearTimeout(logoutTimer);
+    logoutTimer = setTimeout(() => {
+      set({ token: null, user: null });
+      localStorage.removeItem('token');
+      localStorage.removeItem('user');
+      alert('로그인 세션이 만료되었습니다.');
+    }, expiresInMs);
   },
 
   logout: () => {
     set({ token: null, user: null });
     localStorage.removeItem('token');
     localStorage.removeItem('user');
+    if (logoutTimer) clearTimeout(logoutTimer);
   },
 
   hydrate: () => {
@@ -36,6 +56,18 @@ export const useAuthStore = create<AuthState>((set) => ({
     const user = localStorage.getItem('user');
     if (token && user) {
       set({ token, user: JSON.parse(user), hasHydrated: true });
+
+      // 로그인 유지 중에도 만료 타이머 설정
+      const decoded = jwtDecode<JwtPayload>(token);
+      const expiresInMs = decoded.exp * 1000 - Date.now();
+
+      if (logoutTimer) clearTimeout(logoutTimer);
+      logoutTimer = setTimeout(() => {
+        set({ token: null, user: null });
+        localStorage.removeItem('token');
+        localStorage.removeItem('user');
+        alert('로그인 세션이 만료되었습니다.');
+      }, expiresInMs);
     } else {
       set({ hasHydrated: true });
     }


### PR DESCRIPTION
## 📌 개요
- 로그인 시 토큰과 사용자 정보를 localStorage에 저장하여 새로고침 시에도 로그인 상태 유지
- JWT의 `exp` 값을 활용하여 만료 시간 계산 후, 자동 로그아웃 타이머 설정

## 🗒️ 작업 내용 요약
- `useAuthStore`에 `login`, `hydrate` 함수 내부에 자동 로그아웃 로직 추가
- 로그인 유지 및 세션 만료 시 알림 후 로그아웃 처리

## 🔗 관련 이슈
- Closes #29