### PR TITLE
[refactor] 로그인 유무에 따른 페이지 접근 제한 (#31)

### DIFF
--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -3,10 +3,12 @@ import { useModalStore } from '@/store/modalStore';
 import { X } from 'lucide-react';
 import LoginForm from './LoginForm';
 import SignupForm from './SignupForm';
+import { useAuthStore } from '@/store/authStore';
 
 export default function AuthModal() {
   const { modalType, isOpen, openModal, closeModal } = useModalStore();
   const modalRef = useRef<HTMLDivElement>(null);
+  const { token } = useAuthStore();
 
   // 모달 외부 클릭 시 닫기
   useEffect(() => {
@@ -27,6 +29,14 @@ export default function AuthModal() {
       document.body.style.overflow = '';
     }
   }, [isOpen]);
+
+  const handleClickAuth = (type: 'login' | 'signup') => {
+    if (token) {
+      alert('이미 로그인 상태입니다.');
+      return;
+    }
+    openModal(type);
+  };
 
   if (!isOpen) return null;
 
@@ -57,7 +67,7 @@ export default function AuthModal() {
                 계정이 없으신가요?{' '}
                 <span
                   className="text-primary font-semibold cursor-pointer"
-                  onClick={() => openModal('signup')}
+                  onClick={() => handleClickAuth('signup')}
                 >
                   회원가입
                 </span>
@@ -70,7 +80,7 @@ export default function AuthModal() {
                 이미 계정이 있으신가요?{' '}
                 <span
                   className="text-primary font-semibold cursor-pointer"
-                  onClick={() => openModal('login')}
+                  onClick={() => handleClickAuth('login')}
                 >
                   로그인
                 </span>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -17,7 +17,7 @@ const Header = () => {
 
   const navItems = [
     { name: 'FAQ', to: '/faq' },
-    ...(isLoggedIn ? [{ name: '마이페이지', to: '/mypage' }] : []),
+    ...(isLoggedIn ? [{ name: '마이페이지', to: '/mypage' }] : [{ name: '체험하기', to: 'guest' }]),
   ];
 
   const handleLogout = () => {

--- a/src/pages/landing/index.tsx
+++ b/src/pages/landing/index.tsx
@@ -1,12 +1,24 @@
 import { Button } from '@/components/shared';
+import { useAuthStore } from '@/store/authStore';
 import { useModalStore } from '@/store/modalStore';
 import { useNavigate } from 'react-router-dom';
 
 const Landing = () => {
   const navigate = useNavigate();
   const { openModal } = useModalStore();
+  const { token } = useAuthStore();
 
   const handleClick = (action: 'guest' | 'auth') => {
+    if (token) {
+      if (action === 'guest') {
+        alert('이미 로그인 상태입니다. 비회원 체험은 이용할 수 없습니다.');
+      } else if (action === 'auth') {
+        alert('이미 로그인 상태입니다.');
+      }
+      navigate('/main');
+      return;
+    }
+
     if (action === 'guest') {
       navigate('/guest');
     } else if (action === 'auth') {

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -37,65 +37,6 @@ const Main = () => {
 
   // 이력 등록 및 수정 버튼 클릭
   const handleSubmitResume = async (data: PostProfilePayloadData) => {
-    //   const isGuest = !token || searchParams.get('guest') === 'true';
-    //   setLoading(true);
-
-    //   try {
-    //     if (isGuest) {
-    //       // 비회원 추천 요청
-    //       const res = await postGuestCountry({
-    //         education: data.education,
-    //         experience: data.experience,
-    //         skills: data.skills,
-    //         languages: data.languages,
-    //         desiredSalary: data.desiredSalary,
-    //         desiredJob: data.desiredJob,
-    //         additionalNotes: data.additionalNotes,
-    //       });
-
-    //       if (res.code === 200) {
-    //         navigate('/guest', {
-    //           state: { result: res.data.recommendedCountries.rankings },
-    //         });
-    //       } else {
-    //         alert(res.message || '추천 요청에 실패했습니다.');
-    //       }
-    //     } else {
-    //       // 회원: 수정 or 등록
-    //       if (editingResume) {
-    //         const res = await editResume(editingResume.profileId, data, token);
-    //         if (res.code === 200 && res.data) {
-    //           setResumes((prev) =>
-    //             prev.map((item) =>
-    //               item.profileId === editingResume.profileId ? { ...item, ...res.data } : item,
-    //             ),
-    //           );
-    //           alert('이력이 수정되었습니다.');
-    //         } else {
-    //           alert(res.message);
-    //         }
-    //       } else {
-    //         const res = await postResume(data, token);
-    //         if (res.code === 201) {
-    //           alert('이력이 등록되었습니다.');
-    //           const updated = await getResume(token);
-    //           if (updated.code === 200 && updated.data) {
-    //             setResumes(updated.data);
-    //           }
-    //         } else {
-    //           alert(res.message);
-    //         }
-    //       }
-    //     }
-    //   } catch (err) {
-    //     console.error(err);
-    //     alert('처리 중 오류가 발생했습니다.');
-    //   } finally {
-    //     setLoading(false);
-    //     setShowForm(false);
-    //     setEditingResume(null);
-    //   }
-    // };
     if (!token) return;
 
     try {

--- a/src/router/AccessRoute.tsx
+++ b/src/router/AccessRoute.tsx
@@ -1,0 +1,29 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuthStore } from '@/store/authStore';
+import { useModalStore } from '@/store/modalStore';
+
+interface AccessRouteProps {
+  access: 'private' | 'guest';
+}
+
+const AccessRoute = ({ access }: AccessRouteProps) => {
+  const token = useAuthStore((state) => state.token);
+  const openModal = useModalStore((state) => state.openModal);
+
+  if (access === 'private') {
+    if (!token) {
+      openModal('login');
+      return <Navigate to="/" replace />;
+    }
+  }
+
+  if (access === 'guest') {
+    if (token) {
+      return <Navigate to="/main" replace />;
+    }
+  }
+
+  return <Outlet />;
+};
+
+export default AccessRoute;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -9,6 +9,7 @@ import MyPage from '@/pages/mypage';
 import SimulationSummary from '@/components/mypage/SimulationSummarySection';
 import GuestResult from '@/pages/guest/GuestResult';
 import Guest from '@/pages/guest';
+import AccessRoute from './AccessRoute';
 
 interface RouterProps {
   children?: ReactNode;
@@ -18,16 +19,26 @@ export default function Router({ children }: RouterProps) {
   return (
     <BrowserRouter>
       <Routes>
-        {/* 공통 layout 적용 */}
+        {/* 공개 라우트 */}
         <Route index element={<Landing />} />
+
+        {/* 공통 레이아웃 */}
         <Route path="/" element={<Layout />}>
           <Route path="/test" element={<Test />} />
           <Route path="/main" element={<Main />} />
-          <Route path="/mypage" element={<MyPage />} />
-          <Route path="/guest" element={<Guest />} />
-          <Route path="/guest/result" element={<GuestResult />} />
-          <Route path="/recommend/:recommendationId" element={<Recommendation />} />
-          <Route path="/simulation/:simulationId" element={<SimulationSummary />} />
+
+          {/* 비로그인 전용 라우트 */}
+          <Route element={<AccessRoute access="guest" />}>
+            <Route path="/guest" element={<Guest />} />
+            <Route path="/guest/result" element={<GuestResult />} />
+          </Route>
+
+          {/* 로그인 전용 라우트 */}
+          <Route element={<AccessRoute access="private" />}>
+            <Route path="/mypage" element={<MyPage />} />
+            <Route path="/recommend/:recommendationId" element={<Recommendation />} />
+            <Route path="/simulation/:simulationId" element={<SimulationSummary />} />
+          </Route>
         </Route>
       </Routes>
       {children}


### PR DESCRIPTION
## 📌 개요
- 로그인 여부에 따라 특정 페이지 접근을 제한하여 UX 향상
- 비로그인 상태에서는 /mypage 등 보호된 페이지에 접근 시 로그인 모달 표시 또는 리다이렉트 처리
- 로그인 상태에서는 게스트 페이지 접근 차단

## 🗒️ 작업 내용 요약
- 접근 제한을 위한 `AccessRoute` 컴포넌트 생성
- 잘못된 접근 시 경고 및 `/main` 으로 이동

## 🔗 관련 이슈
- Closes #31